### PR TITLE
Suggested Edit: Updated pre-push for Ubuntu

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 echo 'Pushing details to Tracker'
 # Notifies a webhook on attempted "git push".  Called by "git
 # push" after it has checked the remote status, but before anything has been
@@ -24,7 +24,7 @@ function posthook {
   curl "git-receiver.herokuapp.com/commits" \
   -X POST \
   -H "Content-type: application/json" \
-  -d "{\"email\": \""$1"\", \"commits\": ["$2"], \"remote_url\": \""$3"\"}"
+  -d '"{\"email\": \""$1"\", \"commits\": ["$2"], \"remote_url\": \""$3"\"}"'
 }
 
 # Join function in the style of Pascal Pilz


### PR DESCRIPTION
Error on initial push after initializing with makersinit command:
`$ git push origin master
Pushing details to Tracker
.git/hooks/pre-push: 23: .git/hooks/pre-push: function: not found
<h1>Internal Server Error</h1>.git/hooks/pre-push: 28: .git/hooks/pre-push: Syntax error: "}" unexpected
error: failed to push some refs to 'https://github.com/katie210/[projectname]'`

Edited syntax to work with linux system: Ubuntu 14.04
